### PR TITLE
Update archive.html

### DIFF
--- a/templates/archive.html
+++ b/templates/archive.html
@@ -11,7 +11,7 @@
 <p></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":10},"displayLayout":{"type":"list"}} -->
+<!-- wp:query {"queryId":0,"query":{"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"perPage":5},"displayLayout":{"type":"list"},"layout":{"type":"default"}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
 <!-- wp:post-title {"isLink":true} /-->
 


### PR DESCRIPTION
The wp:query parameters would display all posts no matter the category, tag, etc. selected previously. 
This pull request updates the query so archive page queries work correctly.